### PR TITLE
fix: apply suggestions from publint

### DIFF
--- a/.changeset/red-bears-thank.md
+++ b/.changeset/red-bears-thank.md
@@ -1,0 +1,5 @@
+---
+'tiny-node-eventemitter': patch
+---
+
+Fixed package.json exports so that it should be properly importable from ESM and CJS

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Generated files
 /dist/
 /docs/
+*.tgz

--- a/package.json
+++ b/package.json
@@ -17,15 +17,25 @@
 		"event-emitter",
 		"strict types"
 	],
-	"main": "dist/index.cjs.js",
-	"module": "dist/index.esm.js",
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"exports": {
+		"import": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs"
+		},
+		"require": {
+			"types": "./dist/index.d.cts",
+			"require": "./dist/index.cjs"
+		}
+	},
 	"source": "src/index.js",
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"packageManager": "pnpm@9.5.0",
 	"scripts": {
 		"build": "npm run build:types && npm run build:js",
-		"build:types": "tsc --declaration --emitDeclarationOnly -p tsconfig.json",
+		"build:types": "tsc --declaration --emitDeclarationOnly -p tsconfig.json && cp dist/index.d.ts dist/index.d.cts && cp dist/index.d.ts.map dist/index.d.dts.map",
 		"build:js": "rollup -c",
 		"build:docs": "typedoc --out docs src",
 		"test": "node test/index.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,9 @@
-const outputs = ['cjs', 'esm']
-	.map((format) => ({
-		file: `./dist/index.${format}.js`,
+const outputs = [
+	['cjs', 'cjs'],
+	['esm', 'mjs']
+]
+	.map(([format, suffix]) => ({
+		file: `./dist/index.${suffix}`,
 		format,
 		sourcemap: true,
 		sourcemapExcludeSources: true


### PR DESCRIPTION
It got suggested to follow publint's suggestions and warnings for the ESM and CJS compatibility modules.

https://publint.dev/tiny-node-eventemitter@1.0.1