### PR TITLE
chore: remove unused `defaultMaxListeners` export

### DIFF
--- a/.changeset/smart-moons-marry.md
+++ b/.changeset/smart-moons-marry.md
@@ -1,0 +1,5 @@
+---
+'tiny-node-eventemitter': patch
+---
+
+Remove unused `defaultMaxListeners` export

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-export const defaultMaxListeners = Infinity;
 export const errorMonitor = Symbol.for('tinynodeeventemitter.errorMonitor');
 
 // FIXME: implement `emitter[Symbol.for('nodejs.rejection')](err, eventName[, ...args])`


### PR DESCRIPTION
This is unused and thus can get removed.